### PR TITLE
add sphinx_snippet_options

### DIFF
--- a/pg_sphinx.c
+++ b/pg_sphinx.c
@@ -307,3 +307,34 @@ Datum pg_sphinx_snippet(PG_FUNCTION_ARGS)
     PG_RETURN_NULL();
 }
 
+Datum pg_sphinx_snippet_options(PG_FUNCTION_ARGS)
+{
+  PString index = {0, 0}, match = {0, 0}, data = {0, 0}, options = {0, 0};
+  text *result_text = NULL;
+  char *error = NULL;
+  sphinx_config config;
+
+  if (PG_ARGISNULL(0) || PG_ARGISNULL(1) || PG_ARGISNULL(2))
+    PG_RETURN_NULL();
+
+  VARCHAR_TO_PSTRING(index,        PG_GETARG_VARCHAR_P(0), 0);
+  VARCHAR_TO_PSTRING(match,        PG_GETARG_VARCHAR_P(1), 0);
+  VARCHAR_TO_PSTRING(data,         PG_GETARG_VARCHAR_P(2), 0);
+  VARCHAR_TO_PSTRING(options,      PG_GETARG_VARCHAR_P(3), PG_ARGISNULL(3));
+
+  fetch_config(&config);
+  sphinx_snippet_options(&config, &index, &match, &data, &options,
+                         return_text, &result_text, &error);
+
+  if (error) {
+    elog(ERROR, "%s", error);
+    free(error);
+  }
+
+  if (result_text)
+    PG_RETURN_TEXT_P(result_text);
+  else
+    PG_RETURN_NULL();
+}
+
+

--- a/sphinx--0.2.sql
+++ b/sphinx--0.2.sql
@@ -37,6 +37,15 @@ RETURNS VARCHAR
 AS 'sphinx', 'pg_sphinx_snippet'
 LANGUAGE C IMMUTABLE;
 
+CREATE OR REPLACE FUNCTION sphinx_snippet_options(
+  /*index*/     varchar,
+  /*query*/     varchar,
+  /*data*/      varchar,
+  /*options*/   varchar)
+RETURNS VARCHAR
+AS 'sphinx', 'pg_sphinx_snippet_options'
+LANGUAGE C IMMUTABLE;
+
 CREATE TABLE sphinx_config (
   "key"         varchar(32) NOT NULL,
   "value"       varchar(255) NOT NULL,

--- a/sphinx.h
+++ b/sphinx.h
@@ -58,5 +58,14 @@ void sphinx_snippet(sphinx_config *config,
                     void *user_data,
                     char **error);
 
+void sphinx_snippet_options(sphinx_config *config,
+                            const PString *index,
+                            const PString *match,
+                            const PString *data,
+                            const PString *options,
+                            return_data_callback callback,
+                            void *user_data,
+                            char **error);
+
 #endif
 


### PR DESCRIPTION
# select sphinx_snippet_options('documents','order','blah blah order blah ordered blah','1 as query_mode');

server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
The connection to the server was lost. Attempting reset: Failed.
!> \q

I realize this does not correctly quote string options such as before/after, but I'll tackle that if I can get past the current issue.
